### PR TITLE
add slash mention for /rtfs in prefix version

### DIFF
--- a/extensions/rtfx.py
+++ b/extensions/rtfx.py
@@ -97,7 +97,7 @@ class RTFX(commands.Cog):
 
     @commands.command(name="rtfs")
     async def rtfs_prefix(self, ctx: Context, *args: str) -> None:
-        return await ctx.send("Migrated to a slash command, sorry. Use /rtfs")
+        return await ctx.send("Migrated to a slash command, sorry. Use </rtfs:1244441015792701481> instead.")
 
     @commands.command(name="pyright", aliases=["pr"])
     async def _pyright(


### PR DESCRIPTION
I saw somebody try to use the prefix version of /rtfs and saw the hardcoded response. My OCD didn't like seeing the "use /rfts" without a command mention, so this should help relieve my sanity. You don't have to accept it, but I thought should the command ID ever change, worst case is that it will show up as it does now.