### PR TITLE
Refactor codeblock_converter to include language hint

### DIFF
--- a/extensions/dpy.py
+++ b/extensions/dpy.py
@@ -24,9 +24,7 @@ def codeblock_converter(text: str) -> Generator[tuple[str, str]]:
 
     # -2 as there are 3 backticks, so we want to stop at the first backtick to prevent index out of range
     while curr_index < len(text) - 2:
-        if not (text[curr_index] == '`' 
-                and text[curr_index + 1] == '`' 
-                and text[curr_index + 2] == '`'):
+        if not (text[curr_index] == '`' and text[curr_index + 1] == '`' and text[curr_index + 2] == '`'):
             curr_index += 1
             continue
 

--- a/extensions/dpy.py
+++ b/extensions/dpy.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 # helper function to extract codeblocks
-def converter(text: str) -> Generator[tuple[str, str]]:
+def codeblock_converter(text: str) -> Generator[tuple[str, str]]:
     in_codeblock: bool = False
     curr_index: int = 0
     start_index: int = 0

--- a/extensions/dpy.py
+++ b/extensions/dpy.py
@@ -16,21 +16,24 @@ if TYPE_CHECKING:
 
 
 # helper function to extract codeblocks
-def codeblock_converter(text: str) -> Generator[str]:
+def converter(text: str) -> Generator[tuple[str, str]]:
     in_codeblock: bool = False
     curr_index: int = 0
     start_index: int = 0
+    language: str = ""
 
     # -2 as there are 3 backticks, so we want to stop at the first backtick to prevent index out of range
     while curr_index < len(text) - 2:
-        # check if this is the start/end of a codeblock
-        if not (text[curr_index] == '`' and text[curr_index + 1] == '`' and text[curr_index + 2] == '`'):
+        if not (text[curr_index] == '`' 
+                and text[curr_index + 1] == '`' 
+                and text[curr_index + 2] == '`'):
             curr_index += 1
             continue
 
         if in_codeblock:
-            yield text[start_index : curr_index]
+            yield language, text[start_index : curr_index]
             in_codeblock = False
+            language = ""
             curr_index += 3 # jump outside of codeblock
         else:
             curr_index += 3 # jump to start of codeblock
@@ -45,8 +48,11 @@ def codeblock_converter(text: str) -> Generator[str]:
             while temp_index < len(text) - 4:
                 if text[temp_index] == ' ':
                     break
-                # check if this is a language hint
+
                 if text[temp_index] == '\n':
+                    # 15 is just an arbitrary number to ensure the hint isn't infinitely long which might crash something
+                    if 0 < (temp_index - curr_index) < 15:
+                        language = text[curr_index : temp_index]
                     # jump to the start as we don't want to include the language hint
                     curr_index = temp_index + 1 # + 1 to remove the newline
                     break
@@ -93,11 +99,12 @@ class Dpy(commands.Cog):
         if message.content:
             files.append(mystbin.File(filename="message-contents.txt", content=message.content))
 
-            for idx, codeblock in enumerate(codeblock_converter(message.content), start=1):
+            for idx, lang, codeblock in enumerate(codeblock_converter(message.content), start=1):
                 # handle edge-cases like empty codeblocks (i.e., ``````)
                 if not codeblock:
                     continue
-                file = mystbin.File(filename=f"message-contents-code_block_{idx}.py", content=codeblock)
+                file_ext = f".{lang}" if lang else ""
+                file = mystbin.File(filename=f"message-contents-code_block_{idx}{file_ext}", content=codeblock)
                 files.append(file)
 
         for attachment in message.attachments:


### PR DESCRIPTION
This PR allows the language hint used in the codeblock to be the file extension